### PR TITLE
Fix static builds for clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ linux-server:
 
 linux-client:
 	mkdir -p bin/linux
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go get -d -v -x ./cmd/askgod
-	cd bin/linux ; GOOS=linux GOARCH=amd64 go build ../../cmd/askgod
+	GOOS=linux GOARCH=amd64 go get -d -v -x ./cmd/askgod
+	cd bin/linux ; CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ../../cmd/askgod
 
 linux-client-arm:
 	mkdir -p bin/linux-arm
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go get -d -v -x ./cmd/askgod
-	cd bin/linux-arm ; GOOS=linux GOARCH=arm64 go build ../../cmd/askgod
+	GOOS=linux GOARCH=arm64 go get -d -v -x ./cmd/askgod
+	cd bin/linux-arm ; CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ../../cmd/askgod
 
 windows: windows-client windows-server
 
@@ -29,8 +29,8 @@ windows-server:
 
 windows-client:
 	mkdir -p bin/windows
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go get -d -v -x ./cmd/askgod
-	cd bin/windows ; GOOS=windows GOARCH=amd64 go build ../../cmd/askgod
+	GOOS=windows GOARCH=amd64 go get -d -v -x ./cmd/askgod
+	cd bin/windows ; CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ../../cmd/askgod
 
 macos: macos-client macos-client-arm macos-server
 
@@ -41,13 +41,13 @@ macos-server:
 
 macos-client:
 	mkdir -p bin/macos
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go get -d -v -x ./cmd/askgod
-	cd bin/macos ; GOOS=darwin GOARCH=amd64 go build ../../cmd/askgod
+	GOOS=darwin GOARCH=amd64 go get -d -v -x ./cmd/askgod
+	cd bin/macos ; CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build ../../cmd/askgod
 
 macos-client-arm:
 	mkdir -p bin/macos-arm
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go get -d -v -x ./cmd/askgod
-	cd bin/macos-arm ; GOOS=darwin GOARCH=arm64 go build ../../cmd/askgod
+	GOOS=darwin GOARCH=arm64 go get -d -v -x ./cmd/askgod
+	cd bin/macos-arm ; CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ../../cmd/askgod
 
 check:
 	go get -t -v -d -u ./...


### PR DESCRIPTION
The change in 3815dc528618e36c140b74103d580651c3d38c86 did not result in static builds because the `CGO_ENABLED` environment variable was set on the `get` step instead of the `build` step. I've fixed that here.