### PR TITLE
Add an MCP server for askgod at `<askgod_server_address>/mcp`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM golang:latest AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
+RUN apt-get update && apt-get install -y make
 COPY . .
-RUN apt-get update && apt-get install -y make && make linux
+RUN make linux
 
 FROM debian:bookworm-slim
 COPY --from=builder /src/bin/linux/askgod-server /askgod-server

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ This will create two executables in `./bin/linux`: `askgod` and `askgod-server`.
 ```bash
 ./bin/linux/askgod-server ./askgod.yaml.example
 ```
+
+## MCP Server
+
+The askgod server supports an MCP server at `<askgod_server_address>/mcp`.
+This MCP server allows users to submit flags.
+The MCP Server is disabled by default, but can be enabled by setting `mcp: true` in the config.

--- a/api/config.go
+++ b/api/config.go
@@ -9,6 +9,7 @@ type Config struct {
 
 	Daemon   ConfigDaemon   `json:"daemon"   yaml:"daemon"`
 	Database ConfigDatabase `json:"database" yaml:"database"`
+	MCP      bool           `json:"mcp"      yaml:"mcp"`
 }
 
 // ConfigPut represents the editable Askgod configuration.

--- a/api/flag.go
+++ b/api/flag.go
@@ -15,6 +15,7 @@ type Flag struct {
 	Description  string    `json:"description"   yaml:"description"`
 	ReturnString string    `json:"return_string" yaml:"return_string"`
 	Value        int64     `json:"value"         yaml:"value"`
+	AIAgent      bool      `json:"ai_agent"      yaml:"ai_agent"`
 	SubmitTime   time.Time `json:"submit_time"   yaml:"submit_time"`
 }
 
@@ -27,7 +28,8 @@ type FlagPut struct {
 type FlagPost struct {
 	FlagPut `yaml:",inline"`
 
-	Flag string `json:"flag" yaml:"flag"`
+	Flag    string `json:"flag"     yaml:"flag"`
+	AIAgent bool   `json:"ai_agent" yaml:"ai_agent"`
 }
 
 // URL: /1.0/flags

--- a/api/score.go
+++ b/api/score.go
@@ -12,6 +12,7 @@ type AdminScore struct {
 	AdminScorePost `yaml:",inline"`
 
 	ID         int64     `json:"id"          yaml:"id"`
+	AIAgent    bool      `json:"ai_agent"    yaml:"ai_agent"`
 	SubmitTime time.Time `json:"submit_time" yaml:"submit_time"`
 }
 

--- a/api/score.go
+++ b/api/score.go
@@ -26,6 +26,7 @@ type AdminScorePut struct {
 type AdminScorePost struct {
 	AdminScorePut `yaml:",inline"`
 
-	TeamID int64 `json:"team_id" yaml:"team_id"`
-	FlagID int64 `json:"flag_id" yaml:"flag_id"`
+	TeamID  int64 `json:"team_id"  yaml:"team_id"`
+	FlagID  int64 `json:"flag_id"  yaml:"flag_id"`
+	AIAgent bool  `json:"ai_agent" yaml:"ai_agent"`
 }

--- a/askgod.yaml.example
+++ b/askgod.yaml.example
@@ -95,3 +95,6 @@ subnets:
   guests:
     - ::/0
     - 0.0.0.0/0
+
+# Enable or disable the MCP server. Defaults to false.
+mcp: true

--- a/cmd/askgod/cmd_admin_score.go
+++ b/cmd/askgod/cmd_admin_score.go
@@ -110,7 +110,7 @@ func (c *client) cmdAdminListScores(ctx context.Context, _ *cli.Command) error {
 	const layout = "2006/01/02 15:04"
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"ID", "TeamID", "FlagID", "Value", "Submit time", "Notes"})
+	table.SetHeader([]string{"ID", "TeamID", "FlagID", "Value", "Submit time", "AI Agent", "Notes"})
 	table.SetBorder(false)
 	table.SetAutoWrapText(false)
 
@@ -121,6 +121,7 @@ func (c *client) cmdAdminListScores(ctx context.Context, _ *cli.Command) error {
 			strconv.FormatInt(entry.FlagID, 10),
 			strconv.FormatInt(entry.Value, 10),
 			entry.SubmitTime.Local().Format(layout),
+			strconv.FormatBool(entry.AIAgent),
 			entry.Notes,
 		})
 	}

--- a/cmd/askgod/cmd_history.go
+++ b/cmd/askgod/cmd_history.go
@@ -50,7 +50,7 @@ func (c *client) cmdHistory(ctx context.Context, cmd *cli.Command) error {
 	const layout = "2006/01/02 15:04"
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"ID", "Description", "Value", "Timestamp", "Message", "Notes"})
+	table.SetHeader([]string{"ID", "Description", "Value", "Timestamp", "AI Agent", "Message", "Notes"})
 	table.SetBorder(false)
 	table.SetAutoWrapText(false)
 
@@ -60,6 +60,7 @@ func (c *client) cmdHistory(ctx context.Context, cmd *cli.Command) error {
 			flag.Description,
 			strconv.FormatInt(flag.Value, 10),
 			flag.SubmitTime.Local().Format(layout),
+			strconv.FormatBool(flag.AIAgent),
 			flag.ReturnString,
 			flag.Notes,
 		})

--- a/cmd/askgod/cmd_submit.go
+++ b/cmd/askgod/cmd_submit.go
@@ -3,11 +3,33 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/urfave/cli/v3"
 
 	"github.com/nsec/askgod/api"
 )
+
+func hasAIAgentInEnvVariable() bool {
+	for _, env := range []string{
+		"AGENT",
+		"ANTIGRAVITY_AGENT",
+		"CLAUDECODE",
+		"CLAUDE_CODE_IS_COWORK",
+		"CLINE_ACTIVE",
+		"CODEX_SHELL",
+		"CURSOR_AGENT",
+		"GEMINI_CLI",
+		"OPENCODE",
+		"WINDSURF_CASCADE_TERMINAL_KIND",
+	} {
+		if os.Getenv(env) != "" {
+			return true
+		}
+	}
+
+	return false
+}
 
 func (c *client) cmdSubmit(ctx context.Context, cmd *cli.Command) error {
 	if cmd.NArg() != 1 {
@@ -20,6 +42,15 @@ func (c *client) cmdSubmit(ctx context.Context, cmd *cli.Command) error {
 	flag := api.FlagPost{}
 	flag.Flag = cmd.Args().Get(0)
 	flag.Notes = cmd.String("notes")
+	flag.AIAgent = cmd.Bool("agent")
+
+	if !cmd.Bool("no-ai-autodetect") && !flag.AIAgent {
+		flag.AIAgent = hasAIAgentInEnvVariable()
+	}
+
+	if flag.AIAgent {
+		_, _ = fmt.Print("Note: This flag submission is marked as AI-assisted.\n") //nolint:forbidigo
+	}
 
 	// Send the flag
 	resp := api.Flag{}

--- a/cmd/askgod/main.go
+++ b/cmd/askgod/main.go
@@ -231,6 +231,15 @@ func main() {
 					Name:  "notes",
 					Usage: "Some notes to remind you of the flag",
 				},
+				&cli.BoolFlag{
+					Name:  "agent",
+					Usage: "Flag was found mostly or entirely with an AI agent",
+				},
+				&cli.BoolFlag{
+					Name:    "no-ai-autodetect",
+					Sources: cli.EnvVars("ASKGOD_DISABLE_AGENT_AUTODETECT"),
+					Usage:   "Disable automatic AI agent detection",
+				},
 			},
 			Action: c.cmdSubmit,
 		},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       - ${PWD}/askgod.yaml:/askgod.yaml
     command: /askgod.yaml
+    restart: on-failure
     depends_on:
       - database
 

--- a/internal/database/db_scores.go
+++ b/internal/database/db_scores.go
@@ -30,7 +30,7 @@ func (db *DB) GetTeamFlags(ctx context.Context, teamid int64) ([]api.Flag, error
 	resp := []api.Flag{}
 
 	// Query all the scores from the database
-	rows, err := db.QueryContext(ctx, "SELECT score.flagid, flag.description, score.value, score.notes, score.submit_time, flag.return_string FROM score LEFT JOIN flag ON flag.id=score.flagid WHERE score.teamid=$1 ORDER BY score.submit_time ASC;", teamid)
+	rows, err := db.QueryContext(ctx, "SELECT score.flagid, flag.description, score.value, score.notes, score.ai_agent, score.submit_time, flag.return_string FROM score LEFT JOIN flag ON flag.id=score.flagid WHERE score.teamid=$1 ORDER BY score.submit_time ASC;", teamid)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (db *DB) GetTeamFlags(ctx context.Context, teamid int64) ([]api.Flag, error
 	for rows.Next() {
 		row := api.Flag{}
 
-		err := rows.Scan(&row.ID, &row.Description, &row.Value, &row.Notes, &row.SubmitTime, &row.ReturnString)
+		err := rows.Scan(&row.ID, &row.Description, &row.Value, &row.Notes, &row.AIAgent, &row.SubmitTime, &row.ReturnString)
 		if err != nil {
 			return nil, err
 		}
@@ -63,8 +63,8 @@ func (db *DB) GetTeamFlag(ctx context.Context, teamid int64, id int64) (*api.Fla
 	resp := api.Flag{}
 
 	// Query all the scores from the database
-	err := db.QueryRowContext(ctx, "SELECT score.flagid, flag.description, score.value, score.notes, score.submit_time, flag.return_string FROM score LEFT JOIN flag ON flag.id=score.flagid WHERE score.teamid=$1 AND score.flagid=$2 ORDER BY score.submit_time ASC;", teamid, id).Scan(
-		&resp.ID, &resp.Description, &resp.Value, &resp.Notes, &resp.SubmitTime, &resp.ReturnString)
+	err := db.QueryRowContext(ctx, "SELECT score.flagid, flag.description, score.value, score.notes, score.ai_agent, score.submit_time, flag.return_string FROM score LEFT JOIN flag ON flag.id=score.flagid WHERE score.teamid=$1 AND score.flagid=$2 ORDER BY score.submit_time ASC;", teamid, id).Scan(
+		&resp.ID, &resp.Description, &resp.Value, &resp.Notes, &resp.AIAgent, &resp.SubmitTime, &resp.ReturnString)
 	if err != nil {
 		return nil, err
 	}
@@ -124,8 +124,8 @@ func (db *DB) SubmitTeamFlag(ctx context.Context, teamid int64, flag api.FlagPos
 	// Add the flag
 	id = -1
 
-	err = db.QueryRowContext(ctx, "INSERT INTO score (teamid, flagid, value, notes, submit_time) VALUES ($1, $2, $3, $4, $5) RETURNING id;",
-		teamid, row.ID, row.Value, flag.Notes, time.Now()).Scan(&id)
+	err = db.QueryRowContext(ctx, "INSERT INTO score (teamid, flagid, value, notes, submit_time, ai_agent) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id;",
+		teamid, row.ID, row.Value, flag.Notes, time.Now(), flag.AIAgent).Scan(&id)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,8 +133,8 @@ func (db *DB) SubmitTeamFlag(ctx context.Context, teamid int64, flag api.FlagPos
 	// Query the new entry
 	result := api.Flag{}
 
-	err = db.QueryRowContext(ctx, "SELECT score.flagid, flag.description, score.value, score.notes, score.submit_time, flag.return_string FROM score LEFT JOIN flag ON flag.id=score.flagid WHERE score.id=$1;", id).Scan(
-		&result.ID, &result.Description, &result.Value, &result.Notes, &result.SubmitTime, &result.ReturnString)
+	err = db.QueryRowContext(ctx, "SELECT score.flagid, flag.description, score.value, score.notes, score.ai_agent, score.submit_time, flag.return_string FROM score LEFT JOIN flag ON flag.id=score.flagid WHERE score.id=$1;", id).Scan(
+		&result.ID, &result.Description, &result.Value, &result.Notes, &result.AIAgent, &result.SubmitTime, &result.ReturnString)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -148,7 +148,7 @@ func (db *DB) GetScores(ctx context.Context) ([]api.AdminScore, error) {
 	resp := []api.AdminScore{}
 
 	// Query all the scores from the database
-	rows, err := db.QueryContext(ctx, "SELECT id, teamid, flagid, value, notes, submit_time FROM score ORDER BY id ASC;")
+	rows, err := db.QueryContext(ctx, "SELECT id, teamid, flagid, value, notes, ai_agent, submit_time FROM score ORDER BY id ASC;")
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (db *DB) GetScores(ctx context.Context) ([]api.AdminScore, error) {
 	for rows.Next() {
 		row := api.AdminScore{}
 
-		err := rows.Scan(&row.ID, &row.TeamID, &row.FlagID, &row.Value, &row.Notes, &row.SubmitTime)
+		err := rows.Scan(&row.ID, &row.TeamID, &row.FlagID, &row.Value, &row.Notes, &row.AIAgent, &row.SubmitTime)
 		if err != nil {
 			return nil, err
 		}
@@ -180,8 +180,8 @@ func (db *DB) GetScore(ctx context.Context, id int64) (*api.AdminScore, error) {
 	// Query the database entry
 	row := api.AdminScore{}
 
-	err := db.QueryRowContext(ctx, "SELECT id, teamid, flagid, value, notes, submit_time FROM score WHERE id=$1;", id).Scan(
-		&row.ID, &row.TeamID, &row.FlagID, &row.Value, &row.Notes, &row.SubmitTime)
+	err := db.QueryRowContext(ctx, "SELECT id, teamid, flagid, value, notes, ai_agent, submit_time FROM score WHERE id=$1;", id).Scan(
+		&row.ID, &row.TeamID, &row.FlagID, &row.Value, &row.Notes, &row.AIAgent, &row.SubmitTime)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/db_scores.go
+++ b/internal/database/db_scores.go
@@ -194,8 +194,8 @@ func (db *DB) CreateScore(ctx context.Context, score api.AdminScorePost) (int64,
 	id := int64(-1)
 
 	// Create the database entry
-	err := db.QueryRowContext(ctx, "INSERT INTO score (teamid, flagid, value, notes, submit_time) VALUES ($1, $2, $3, $4, $5) RETURNING id",
-		score.TeamID, score.FlagID, score.Value, score.Notes, time.Now()).Scan(&id)
+	err := db.QueryRowContext(ctx, "INSERT INTO score (teamid, flagid, value, notes, ai_agent, submit_time) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
+		score.TeamID, score.FlagID, score.Value, score.Notes, score.AIAgent, time.Now()).Scan(&id)
 	if err != nil {
 		return -1, err
 	}

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS score (
     value INTEGER NOT NULL DEFAULT 0,
     submit_time TIMESTAMP WITH TIME ZONE,
     notes VARCHAR,
+    ai_agent BOOLEAN NOT NULL DEFAULT FALSE,
     FOREIGN KEY (teamid) REFERENCES team (id) ON DELETE CASCADE,
     FOREIGN KEY (flagid) REFERENCES flag (id) ON DELETE CASCADE,
     UNIQUE(teamid, flagid)

--- a/internal/database/updates.go
+++ b/internal/database/updates.go
@@ -10,6 +10,7 @@ import (
 var dbUpdates = []dbUpdate{
 	{version: 1, run: dbUpdateFromV0},
 	{version: 2, run: dbUpdateFromV1},
+	{version: 3, run: dbUpdateFromV2},
 }
 
 type dbUpdate struct {
@@ -48,6 +49,12 @@ CREATE TABLE IF NOT EXISTS config (
     UNIQUE(key)
 );
 	`)
+
+	return err
+}
+
+func dbUpdateFromV2(ctx context.Context, _, _ int, db *DB) error {
+	_, err := db.ExecContext(ctx, "ALTER TABLE score ADD COLUMN ai_agent BOOLEAN NOT NULL DEFAULT FALSE;")
 
 	return err
 }

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1,0 +1,169 @@
+// Package mcp implements an MCP server using Streamable HTTP transport.
+package mcp
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/inconshreveable/log15"
+)
+
+// MCP implements an MCP server using Streamable HTTP transport.
+type MCP struct {
+	logger  log15.Logger
+	handler http.Handler
+}
+
+// NewMCP creates a new MCP server instance.
+func NewMCP(handler http.Handler, logger log15.Logger) *MCP {
+	return &MCP{
+		handler: handler,
+		logger:  logger,
+	}
+}
+
+// ServeHTTP handles incoming MCP requests over Streamable HTTP.
+func (m *MCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+
+		return
+	}
+
+	var req Request
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		m.writeError(w, nil, -32700, "Parse error")
+
+		return
+	}
+
+	// Notifications have no id — respond with 202 Accepted.
+	if req.ID == nil {
+		w.WriteHeader(http.StatusAccepted)
+
+		return
+	}
+
+	var id any
+
+	err = json.Unmarshal(*req.ID, &id)
+	if err != nil {
+		id = nil
+	}
+
+	switch req.Method {
+	case "initialize":
+		m.handleInitialize(w, id)
+	case "tools/list":
+		m.handleToolsList(w, id)
+	case "tools/call":
+		m.handleToolsCall(w, r, id, req.Params)
+	default:
+		m.writeError(w, id, -32601, "Method not found")
+	}
+}
+
+func (m *MCP) handleInitialize(w http.ResponseWriter, id any) {
+	result := InitializeResult{
+		ProtocolVersion: "2025-03-26",
+		Capabilities: Capabilities{
+			Tools: &ToolsCapability{},
+		},
+		ServerInfo: ServerInfo{
+			Name:    "askgod",
+			Version: "1.0.0",
+		},
+	}
+
+	m.writeResult(w, id, result)
+}
+
+func (m *MCP) handleToolsList(w http.ResponseWriter, id any) {
+	result := ListToolsResult{
+		Tools: []Tool{
+			{
+				Name:        "submit_flag",
+				Description: "Submit a CTF flag for your team. Returns whether the flag was valid, already submitted, or invalid.",
+				InputSchema: ToolInputSchema{
+					Type: "object",
+					Properties: map[string]any{
+						"flag": map[string]any{
+							"type":        "string",
+							"description": "The flag string to submit",
+						},
+					},
+					Required: []string{"flag"},
+				},
+			},
+		},
+	}
+
+	m.writeResult(w, id, result)
+}
+
+func (m *MCP) handleToolsCall(w http.ResponseWriter, r *http.Request, id any, params json.RawMessage) {
+	var p CallToolParams
+
+	err := json.Unmarshal(params, &p)
+	if err != nil {
+		m.writeError(w, id, -32602, "Invalid params")
+
+		return
+	}
+
+	var result CallToolResult
+
+	switch p.Name {
+	case "submit_flag":
+		result = m.submitFlag(r, p.Arguments)
+	default:
+		m.writeError(w, id, -32602, "Unknown tool: "+p.Name)
+
+		return
+	}
+
+	m.writeResult(w, id, result)
+}
+
+func (m *MCP) writeResult(w http.ResponseWriter, id any, result any) {
+	resp := Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	err := json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		m.logger.Error("Failed to encode response", log15.Ctx{"error": err})
+	}
+}
+
+func (m *MCP) writeError(w http.ResponseWriter, id any, code int, message string) {
+	resp := Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &Error{
+			Code:    code,
+			Message: message,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	err := json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		m.logger.Error("Failed to encode error response", log15.Ctx{"error": err})
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -1,0 +1,83 @@
+package mcp
+
+import "encoding/json"
+
+// Request is a JSON-RPC 2.0 request.
+type Request struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string           `json:"method"`
+	Params  json.RawMessage  `json:"params,omitempty"`
+}
+
+// Response is a JSON-RPC 2.0 response.
+type Response struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      any    `json:"id"`
+	Result  any    `json:"result,omitempty"`
+	Error   *Error `json:"error,omitempty"`
+}
+
+// Error is a JSON-RPC 2.0 error.
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// InitializeResult is the result of an MCP initialize request.
+type InitializeResult struct {
+	ProtocolVersion string       `json:"protocolVersion"` //nolint:tagliatelle
+	Capabilities    Capabilities `json:"capabilities"`
+	ServerInfo      ServerInfo   `json:"serverInfo"` //nolint:tagliatelle
+}
+
+// Capabilities describes what the server supports.
+type Capabilities struct {
+	Tools *ToolsCapability `json:"tools,omitempty"`
+}
+
+// ToolsCapability indicates the server supports tools.
+type ToolsCapability struct{}
+
+// ServerInfo holds the server name and version.
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// Tool is a tool available on the server.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema ToolInputSchema `json:"inputSchema"` //nolint:tagliatelle
+}
+
+// ToolInputSchema is a JSON Schema object describing the tool's parameters.
+type ToolInputSchema struct {
+	Type       string         `json:"type"`
+	Properties map[string]any `json:"properties,omitempty"`
+	Required   []string       `json:"required,omitempty"`
+}
+
+// CallToolParams holds the parameters for a tools/call request.
+type CallToolParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
+// CallToolResult holds the result of a tool call.
+type CallToolResult struct {
+	Content []Content `json:"content"`
+	IsError bool      `json:"isError,omitempty"` //nolint:tagliatelle
+}
+
+// Content is a content block in a tool result.
+type Content struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ListToolsResult holds the result of a tools/list request.
+type ListToolsResult struct {
+	Tools []Tool `json:"tools"`
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,53 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/nsec/askgod/api"
+)
+
+func (m *MCP) submitFlag(r *http.Request, args map[string]any) CallToolResult {
+	flagStr, ok := args["flag"].(string)
+	if !ok || flagStr == "" {
+		return errorResult("Missing or invalid 'flag' argument")
+	}
+
+	body, err := json.Marshal(api.FlagPost{Flag: flagStr, AIAgent: true})
+	if err != nil {
+		return errorResult("Internal server error")
+	}
+
+	req, _ := http.NewRequestWithContext(r.Context(), http.MethodPost, "/1.0/team/flags", bytes.NewReader(body))
+	req.RemoteAddr = r.RemoteAddr
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	m.handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		return errorResult(strings.TrimSpace(rec.Body.String()))
+	}
+
+	var result api.Flag
+
+	err = json.NewDecoder(rec.Body).Decode(&result)
+	if err != nil {
+		return errorResult("Internal server error")
+	}
+
+	msg := fmt.Sprintf("Correct flag! +%d points\n", result.Value)
+	if result.ReturnString != "" {
+		msg += fmt.Sprintf("Return message: %s\n", result.ReturnString)
+	}
+
+	return CallToolResult{Content: []Content{{Type: "text", Text: msg}}}
+}
+
+func errorResult(msg string) CallToolResult {
+	return CallToolResult{Content: []Content{{Type: "text", Text: msg}}, IsError: true}
+}

--- a/internal/rest/api_flags.go
+++ b/internal/rest/api_flags.go
@@ -228,7 +228,7 @@ func (r *rest) submitTeamFlag(writer http.ResponseWriter, request *http.Request,
 	case errors.Is(err, sql.ErrNoRows):
 		metricSubmitTeam.WithLabelValues(strconv.FormatInt(team.ID, 10), "invalid").Inc()
 		_ = r.eventSend("flags", api.EventFlag{Team: *team, Input: flag.Flag, Type: "invalid"})
-		logger.Info("Invalid flag submitted", log15.Ctx{"teamid": team.ID, "flag": flag.Flag})
+		logger.Info("Invalid flag submitted", log15.Ctx{"teamid": team.ID, "ai-agent": flag.AIAgent, "flag": flag.Flag})
 		r.errorResponse(400, "Invalid flag submitted", writer, request)
 
 		return
@@ -236,14 +236,14 @@ func (r *rest) submitTeamFlag(writer http.ResponseWriter, request *http.Request,
 	case errors.Is(err, os.ErrExist):
 		metricSubmitTeam.WithLabelValues(strconv.FormatInt(team.ID, 10), "duplicate").Inc()
 		_ = r.eventSend("flags", api.EventFlag{Team: *team, Flag: adminFlag, Input: flag.Flag, Value: 0, Type: "duplicate"})
-		logger.Info("The flag was already submitted", log15.Ctx{"teamid": team.ID, "flag": flag.Flag})
+		logger.Info("The flag was already submitted", log15.Ctx{"teamid": team.ID, "ai-agent": flag.AIAgent, "flag": flag.Flag})
 		r.errorResponse(400, "The flag was already submitted", writer, request)
 
 		return
 
 	case err != nil:
 		metricSubmitTeam.WithLabelValues(strconv.FormatInt(team.ID, 10), "error").Inc()
-		logger.Error("Failed to submit the flag", log15.Ctx{"error": err, "teamid": team.ID})
+		logger.Error("Failed to submit the flag", log15.Ctx{"error": err, "teamid": team.ID, "ai-agent": flag.AIAgent})
 		r.errorResponse(500, "Internal Server Error", writer, request)
 
 		return
@@ -280,7 +280,7 @@ func (r *rest) submitTeamFlag(writer http.ResponseWriter, request *http.Request,
 
 	_ = r.eventSend("timeline", api.EventTimeline{TeamID: team.ID, Team: &team.TeamPut, Score: &score, Type: "score-updated"})
 
-	logger.Info("Correct flag submitted", log15.Ctx{"teamid": team.ID, "flagid": result.ID, "value": result.Value, "flag": flag.Flag})
+	logger.Info("Correct flag submitted", log15.Ctx{"teamid": team.ID, "flagid": result.ID, "value": result.Value, "ai-agent": flag.AIAgent, "flag": flag.Flag})
 	r.jsonResponse(result, writer, request)
 }
 

--- a/internal/rest/api_scores.go
+++ b/internal/rest/api_scores.go
@@ -118,7 +118,7 @@ func (r *rest) adminCreateScoreCommon(writer http.ResponseWriter, request *http.
 
 	_ = r.eventSend("timeline", api.EventTimeline{TeamID: team.ID, Team: &team.TeamPut, Score: &score, Type: "score-updated"})
 
-	logger.Info("New score entry defined", log15.Ctx{"id": id, "flagid": newScore.FlagID, "teamid": newScore.TeamID, "value": newScore.Value})
+	logger.Info("New score entry defined", log15.Ctx{"id": id, "flagid": newScore.FlagID, "teamid": newScore.TeamID, "value": newScore.Value, "ai_agent": newScore.AIAgent})
 
 	return true
 }

--- a/internal/rest/attach.go
+++ b/internal/rest/attach.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nsec/askgod/internal/config"
 	"github.com/nsec/askgod/internal/database"
+	"github.com/nsec/askgod/internal/mcp"
 )
 
 var clusterPeers []string
@@ -55,6 +56,16 @@ func AttachFunctions(ctx context.Context, conf *config.Config, router *http.Serv
 
 	r.registerEndpoint("/1.0/teams", "admin", r.adminGetTeams, r.adminCreateTeam, nil, r.adminClearTeams)
 	r.registerEndpoint("/1.0/teams/{id}", "admin", r.adminGetTeam, nil, r.adminUpdateTeam, r.adminDeleteTeam)
+
+	// MCP server endpoint (disabled by default)
+	if conf.MCP {
+		r.logger.Info("Starting the MCP server")
+		mcpServer := mcp.NewMCP(r.router, logger.New("component", "mcp"))
+
+		r.registerEndpoint("/mcp", "team", nil, func(writer http.ResponseWriter, request *http.Request, _ log15.Logger) {
+			mcpServer.ServeHTTP(writer, request)
+		}, nil, nil)
+	}
 
 	// Setup forwarder
 	for _, peer := range conf.Daemon.ClusterPeers {

--- a/seed_data.sh
+++ b/seed_data.sh
@@ -4,7 +4,7 @@
 
 TEAM_NAME="seed-testteam"
 echo "Adding team $TEAM_NAME"
-./bin/linux/askgod --server http://localhost:9080 admin add-team name=$TEAM_NAME subnets=127.0.0.1/8 country=CA
+./bin/linux/askgod --server http://localhost:9080 admin add-team name=$TEAM_NAME subnets=0.0.0.0/0 country=CA
 
 FLAG_PREFIX="FLAG-SEED-"
 echo "Adding 20 flags $FLAG_PREFIX{NUMBER}"

--- a/seed_data.sh
+++ b/seed_data.sh
@@ -2,13 +2,27 @@
 
 # Add test data in the askgod instance. Make sure to run `make linux` before running this file, and to run it from the project root directory.
 
-TEAM_NAME="seed-testteam"
-echo "Adding team $TEAM_NAME"
-./bin/linux/askgod --server http://localhost:9080 admin add-team name=$TEAM_NAME subnets=0.0.0.0/0 country=CA
+TEAM_NAME_PREFIX="seed-testteam-"
+for i in {1..80}
+do
+    TEAM_NAME="${TEAM_NAME_PREFIX}${i}"
+    echo "Adding team $TEAM_NAME"
+    ./bin/linux/askgod --server http://localhost:9080 admin add-team name=$TEAM_NAME subnets=0.0.0.0/0 country=CA
+done
 
 FLAG_PREFIX="FLAG-SEED-"
 echo "Adding 20 flags $FLAG_PREFIX{NUMBER}"
 for i in {1..20}
 do
 ./bin/linux/askgod --server http://localhost:9080 admin add-flag flag=$FLAG_PREFIX$i value=$i description="Seed flag #$i" return_string="Seed flag #$i"
+done
+
+echo "Adding 100 scores"
+for i in {1..100}
+do
+    TEAM_ID=$(( ( RANDOM % 80 )  + 1 ))
+    FLAG_ID=$(( ( RANDOM % 20 )  + 1 ))
+    AI_AGENT=$( (( RANDOM % 2 == 1 )) && echo "true" || echo "false" )
+    echo "Adding score for team_id=$TEAM_ID flag_id=$FLAG_ID ai_agent=$AI_AGENT" value=$FLAG_ID
+    ./bin/linux/askgod --server http://localhost:9080 admin add-score team_id=$TEAM_ID flag_id=$FLAG_ID ai_agent=$AI_AGENT value=$FLAG_ID
 done


### PR DESCRIPTION
Add an MCP server for askgod at `<askgod_server_address>/mcp`.

It has two methods: one to submit flags and one to list the scoreboard.
The list scoreboard method contains a small prompt injection to troll the players. 

A new column is added to the `scores` table: `source`. Its purpose is to track if the flag was submitted using the REST API or using MCP. 

The `askgod admin list-scores` aud `askgod history` commands were changed to display the source of each flag.

Note: This PR was mainly vibecoded using Claude Code, but I reviewed all of it. However, I'm not a golang expert so a thorough review would be appreciated.