### PR TITLE
Allow admins to search for their tracks

### DIFF
--- a/cmd/askgod/cmd_admin_history.go
+++ b/cmd/askgod/cmd_admin_history.go
@@ -14,7 +14,9 @@ import (
 	"github.com/nsec/askgod/internal/utils"
 )
 
-func (c *client) cmdAdminHistory(ctx context.Context, _ *cli.Command) error {
+func (c *client) cmdAdminHistory(ctx context.Context, cmd *cli.Command) error {
+	flagIDs := cmd.Int64Slice("flags")
+
 	// Get the scores
 	scores := []api.AdminScore{}
 
@@ -51,6 +53,10 @@ func (c *client) cmdAdminHistory(ctx context.Context, _ *cli.Command) error {
 	table.SetAutoWrapText(false)
 
 	for _, entry := range scores {
+		if !matchesFlagIDs(entry.FlagID, flagIDs) {
+			continue
+		}
+
 		// Get the team
 		team := api.AdminTeam{}
 

--- a/cmd/askgod/cmd_admin_monitor.go
+++ b/cmd/askgod/cmd_admin_monitor.go
@@ -81,6 +81,8 @@ func (c *client) cmdAdminMonitorLog(_ context.Context, cmd *cli.Command) error {
 }
 
 func (c *client) cmdAdminMonitorFlags(_ context.Context, cmd *cli.Command) error {
+	flagIDs := cmd.Int64Slice("flags")
+
 	humanOnly := cmd.Bool("human")
 
 	// Connection handler
@@ -112,6 +114,10 @@ func (c *client) cmdAdminMonitorFlags(_ context.Context, cmd *cli.Command) error
 
 		err = json.Unmarshal(event.Metadata, &score)
 		if err != nil {
+			continue
+		}
+
+		if !flagMatchesIDs(score.Flag, flagIDs) {
 			continue
 		}
 

--- a/cmd/askgod/main.go
+++ b/cmd/askgod/main.go
@@ -58,6 +58,10 @@ func main() {
 					Usage:    "Show a live stream of submitted flags",
 					Category: "server",
 					Flags: []cli.Flag{
+						&cli.Int64SliceFlag{
+							Name:  "flags",
+							Usage: "Only show entries for flags with the given IDs",
+						},
 						&cli.BoolFlag{
 							Name:  "human",
 							Usage: "Only show submissions from human sources (excludes agent/mcp)",
@@ -195,7 +199,13 @@ func main() {
 					Name:     "history",
 					Usage:    "List the global flag history",
 					Category: "scores",
-					Action:   c.cmdAdminHistory,
+					Flags: []cli.Flag{
+						&cli.Int64SliceFlag{
+							Name:  "flags",
+							Usage: "Only show entries for flags with the given IDs",
+						},
+					},
+					Action: c.cmdAdminHistory,
 				},
 				{
 					Name:     "stats",

--- a/cmd/askgod/utils.go
+++ b/cmd/askgod/utils.go
@@ -3,11 +3,33 @@ package main
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
+	"github.com/nsec/askgod/api"
 	"github.com/nsec/askgod/internal/utils"
 )
+
+func matchesFlagIDs(flagID int64, flagIDs []int64) bool {
+	if len(flagIDs) == 0 {
+		return true
+	}
+
+	return slices.Contains(flagIDs, flagID)
+}
+
+func flagMatchesIDs(flag *api.AdminFlag, flagIDs []int64) bool {
+	if len(flagIDs) == 0 {
+		return true
+	}
+
+	if flag == nil {
+		return false
+	}
+
+	return matchesFlagIDs(flag.ID, flagIDs)
+}
 
 func getStructField(base reflect.Value, key string) (reflect.Value, error) {
 	field := base


### PR DESCRIPTION
During the competition, a lot of challenge designers are monitoring solves on their tracks.
This allows designers to filter the `history` and `monitor-flags` outputs for their flag IDs.