### PR TITLE
Flag submission rate limiting with admin WebSocket alerts

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -14,9 +14,10 @@ type Config struct {
 
 // ConfigPut represents the editable Askgod configuration.
 type ConfigPut struct {
-	Scoring ConfigScoring `json:"scoring" yaml:"scoring"`
-	Teams   ConfigTeams   `json:"teams"   yaml:"teams"`
-	Subnets ConfigSubnets `json:"subnets" yaml:"subnets"`
+	Scoring   ConfigScoring   `json:"scoring"    yaml:"scoring"`
+	Teams     ConfigTeams     `json:"teams"      yaml:"teams"`
+	Subnets   ConfigSubnets   `json:"subnets"    yaml:"subnets"`
+	RateLimit ConfigRateLimit `json:"rate_limit" yaml:"rate_limit"`
 }
 
 // ConfigDaemon represents the Daemon part of the Askgod configuration.
@@ -57,6 +58,16 @@ type ConfigTeams struct {
 	SelfRegister bool     `json:"self_register" yaml:"self_register"`
 	SelfUpdate   bool     `json:"self_update"   yaml:"self_update"`
 	Hidden       []string `json:"hidden"        yaml:"hidden"`
+}
+
+// ConfigRateLimit represents the rate limiting part of the Askgod configuration.
+// Rate is the token refill rate in submissions per second.
+// Burst is the maximum burst capacity (bucket size).
+// GracePeriod is how long (in minutes) a team is blocked after busting the limit.
+type ConfigRateLimit struct {
+	Rate        float64 `json:"rate"         yaml:"rate"`
+	Burst       float64 `json:"burst"        yaml:"burst"`
+	GracePeriod float64 `json:"grace_period" yaml:"grace_period"`
 }
 
 // ConfigSubnets represents the Daemon part of the Askgod configuration.

--- a/api/event.go
+++ b/api/event.go
@@ -41,6 +41,14 @@ type EventTimeline struct {
 	Type   string              `json:"type"   yaml:"type"`
 }
 
+// EventRateLimit represents a rate-limit state change event (admin only).
+// Type is "blocked" when the team first exceeds the limit, "unblocked" when
+// the grace period expires and the team is allowed to submit again.
+type EventRateLimit struct {
+	Team AdminTeam `json:"team" yaml:"team"`
+	Type string    `json:"type" yaml:"type"`
+}
+
 // EventInternal represents an internal syncronisation event.
 type EventInternal struct {
 	Type string `json:"type" yaml:"type"`

--- a/cmd/askgod/cmd_admin_monitor.go
+++ b/cmd/askgod/cmd_admin_monitor.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/inconshreveable/log15"
@@ -141,6 +143,65 @@ func (c *client) cmdAdminMonitorFlags(_ context.Context, cmd *cli.Command) error
 			_, _ = fmt.Printf("[%s][%s] Team \"%s\" (%s) submitted invalid flag \"%s\" [%s]\n", //nolint:forbidigo
 				event.Server, event.Timestamp.Local().Format(layout), score.Team.Name, team, score.Input, score.Source)
 		default:
+		}
+	}
+
+	return nil //nolint:nilerr
+}
+
+// wsChannelForEventType maps user-facing event type names to websocket channel
+// names. "ratelimit" events travel on the "flags" channel.
+var wsChannelForEventType = map[string]string{
+	"flags":     "flags",
+	"logging":   "logging",
+	"timeline":  "timeline",
+	"ratelimit": "flags",
+}
+
+// cmdAdminMonitorHook connects to the requested event channels and calls
+// <script> for every received event, passing the raw event JSON on stdin.
+// The event JSON has the shape: {"server":..., "type":..., "timestamp":..., "metadata":{...}}
+func (c *client) cmdAdminMonitorHook(_ context.Context, cmd *cli.Command) error {
+	if cmd.NArg() == 0 {
+		return fmt.Errorf("missing required argument: <script>")
+	}
+
+	script := cmd.Args().First()
+
+	// Build the deduplicated list of websocket channels to subscribe to.
+	seen := map[string]bool{}
+	wsChannels := []string{}
+
+	for _, t := range strings.Split(cmd.String("event"), ",") {
+		t = strings.TrimSpace(t)
+
+		ch, ok := wsChannelForEventType[t]
+		if !ok {
+			return fmt.Errorf("unknown event type %q (valid: flags, logging, timeline, ratelimit)", t)
+		}
+
+		if !seen[ch] {
+			seen[ch] = true
+			wsChannels = append(wsChannels, ch)
+		}
+	}
+
+	conn, err := c.websocket("/events?type=" + strings.Join(wsChannels, ","))
+	if err != nil {
+		return err
+	}
+
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+
+		hookCmd := exec.Command(script) //nolint:gosec
+		hookCmd.Stdin = bytes.NewReader(data)
+
+		if err := hookCmd.Run(); err != nil {
+			_, _ = fmt.Printf("hook error: %v\n", err) //nolint:forbidigo
 		}
 	}
 

--- a/cmd/askgod/main.go
+++ b/cmd/askgod/main.go
@@ -69,6 +69,20 @@ func main() {
 					},
 					Action: c.cmdAdminMonitorFlags,
 				},
+				{
+					Name:      "monitor-hook",
+					Usage:     "Call a script for each matching event",
+					ArgsUsage: "<script>",
+					Category:  "server",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:     "event",
+							Usage:    "Comma-separated event types to monitor: flags, logging, timeline, ratelimit",
+							Required: true,
+						},
+					},
+					Action: c.cmdAdminMonitorHook,
+				},
 
 				{
 					Name:      "add-flag",

--- a/internal/rest/api_flags.go
+++ b/internal/rest/api_flags.go
@@ -235,6 +235,27 @@ func (r *rest) submitTeamFlag(writer http.ResponseWriter, request *http.Request,
 		return
 	}
 
+	// Check rate limit.
+	rl := r.config.RateLimit
+	switch r.rateLimiter.check(team.ID, rl.Rate, rl.Burst, rl.GracePeriod) {
+	case RateLimitFirstBreach:
+		logger.Warn("Team exceeded flag submission rate limit", log15.Ctx{"teamid": team.ID})
+		_ = r.eventSend("flags", api.EventRateLimit{Team: *team, Type: "blocked"})
+		r.errorResponse(429, "Too many requests", writer, request)
+
+		return
+
+	case RateLimitBlocked:
+		logger.Debug("Team flag submission blocked (rate limit grace period)", log15.Ctx{"teamid": team.ID})
+		r.errorResponse(429, "Too many requests", writer, request)
+
+		return
+
+	case RateLimitUnblocked:
+		logger.Info("Team rate limit grace period expired", log15.Ctx{"teamid": team.ID})
+		_ = r.eventSend("flags", api.EventRateLimit{Team: *team, Type: "unblocked"})
+	}
+
 	// Submit the flag
 	result, adminFlag, err := r.db.SubmitTeamFlag(request.Context(), team.ID, flag)
 	switch {

--- a/internal/rest/attach.go
+++ b/internal/rest/attach.go
@@ -19,10 +19,11 @@ var clusterPeers []string
 // AttachFunctions attaches all the REST API functions to the provided router.
 func AttachFunctions(ctx context.Context, conf *config.Config, router *http.ServeMux, db *database.DB, logger log15.Logger) error {
 	r := rest{
-		config: conf,
-		db:     db,
-		logger: logger,
-		router: router,
+		config:      conf,
+		db:          db,
+		logger:      logger,
+		router:      router,
+		rateLimiter: newTeamRateLimiter(),
 	}
 
 	// Update the list of hidden teams

--- a/internal/rest/ratelimit.go
+++ b/internal/rest/ratelimit.go
@@ -1,0 +1,118 @@
+package rest
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	defaultRateLimitRate  = 5.0
+	defaultRateLimitBurst = 10.0
+)
+
+// RateLimitResult describes the outcome of a rate-limit check.
+type RateLimitResult int
+
+const (
+	// RateLimitAllowed means the submission is within limits.
+	RateLimitAllowed RateLimitResult = iota
+	// RateLimitFirstBreach means the team just exceeded the limit for the first
+	// time; callers should emit a "blocked" alert event and reject the request.
+	RateLimitFirstBreach
+	// RateLimitBlocked means the team is still within a grace-period block;
+	// callers should reject the request without re-emitting an event.
+	RateLimitBlocked
+	// RateLimitUnblocked means the grace period just expired and this request
+	// is allowed; callers should emit an "unblocked" alert event and proceed.
+	RateLimitUnblocked
+)
+
+type teamRateLimitState struct {
+	mu           sync.Mutex
+	tokens       float64
+	lastRefil    time.Time
+	blockedUntil time.Time
+}
+
+// check applies token-bucket logic and returns the appropriate RateLimitResult.
+// rate, burst, and gracePeriodMinutes are read from config on every call so
+// live config reloads take effect immediately.
+func (s *teamRateLimitState) check(now time.Time, rate, burst, gracePeriodMinutes float64) RateLimitResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If still within the grace-period block, keep rejecting.
+	if now.Before(s.blockedUntil) {
+		return RateLimitBlocked
+	}
+
+	// Grace period just expired — clear the block and signal the unblock.
+	wasBlocked := !s.blockedUntil.IsZero()
+	s.blockedUntil = time.Time{}
+
+	// Refill tokens based on elapsed time.
+	elapsed := now.Sub(s.lastRefil).Seconds()
+	s.tokens += elapsed * rate
+	if s.tokens > burst {
+		s.tokens = burst
+	}
+
+	s.lastRefil = now
+
+	if s.tokens >= 1 {
+		s.tokens--
+
+		if wasBlocked {
+			return RateLimitUnblocked
+		}
+
+		return RateLimitAllowed
+	}
+
+	// Bucket still empty after grace period — start a new block.
+	s.blockedUntil = now.Add(time.Duration(gracePeriodMinutes * float64(time.Minute)))
+
+	return RateLimitFirstBreach
+}
+
+type teamRateLimiter struct {
+	mu     sync.Mutex
+	states map[int64]*teamRateLimitState
+}
+
+func newTeamRateLimiter() *teamRateLimiter {
+	return &teamRateLimiter{
+		states: make(map[int64]*teamRateLimitState),
+	}
+}
+
+// check records a flag submission for teamID and returns the rate-limit outcome.
+// Returns RateLimitAllowed when rate limiting is disabled (gracePeriod is zero
+// or negative). Rate defaults to defaultRateLimitRate and burst defaults to
+// defaultRateLimitBurst when not set in config.
+func (rl *teamRateLimiter) check(teamID int64, rate, burst, gracePeriodMinutes float64) RateLimitResult {
+	if gracePeriodMinutes <= 0 {
+		return RateLimitAllowed
+	}
+
+	if rate <= 0 {
+		rate = defaultRateLimitRate
+	}
+
+	if burst <= 0 {
+		burst = defaultRateLimitBurst
+	}
+
+	rl.mu.Lock()
+	state, ok := rl.states[teamID]
+	if !ok {
+		state = &teamRateLimitState{
+			tokens:    burst,
+			lastRefil: time.Now(),
+		}
+		rl.states[teamID] = state
+	}
+	rl.mu.Unlock()
+
+	return state.check(time.Now(), rate, burst, gracePeriodMinutes)
+}

--- a/internal/rest/struct.go
+++ b/internal/rest/struct.go
@@ -15,4 +15,5 @@ type rest struct {
 	logger      log15.Logger
 	router      *http.ServeMux
 	hiddenTeams []int64
+	rateLimiter *teamRateLimiter
 }


### PR DESCRIPTION
  A per-team token-bucket rate limiter sits in front of the flag submission handler. When a team exhausts their token
  bucket, they receive HTTP 429 responses for the duration of a configurable grace period. The limiter tracks four
  states to minimize event noise:

  - Allowed — normal submission, proceeds as usual
  - FirstBreach — bucket just emptied; emits a blocked WebSocket event and starts the grace period
  - Blocked — team is in the grace period; silently rejects with 429
  - Unblocked — grace period has expired on this request; emits an unblocked WebSocket event and allows the submission
   through

  Rate and burst default to 5 req/s and a burst of 10 so the limiter works out of the box, but all three parameters
  are in the live-reloadable config section so they can be tuned during an event without a server restart.

  New config section (api/config.go)

  rate_limit:
    rate: 5.0          # tokens refilled per second (default: 5)
    burst: 10.0        # max burst before tripping (default: 10)
    grace_period: 5.0  # minutes blocked after first breach (required to enable)

  Rate limiting is disabled when grace_period is not set, so existing deployments are unaffected.

  EventRateLimit is emitted on the existing flags admin channel with type: "blocked" or "unblocked", so any existing
  flag monitor clients receive these events without needing to subscribe to a new channel.

  Admin hook command (cmd/askgod)

  askgod admin monitor-hook --event ratelimit /path/to/script.sh

  Connects to the requested event channels and invokes the given script for every matching event, with the full event
  JSON on stdin. Multiple event types can be combined (--event ratelimit,flags).